### PR TITLE
Give generated tests typed descriptions

### DIFF
--- a/packages/schematics/angular/application/other-files/app.component.spec.ts.template
+++ b/packages/schematics/angular/application/other-files/app.component.spec.ts.template
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';<% if (routing) { %>
 import { RouterTestingModule } from '@angular/router/testing';<% } %>
 import { AppComponent } from './app.component';
 
-describe('AppComponent', () => {
+describe(AppComponent.name, () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({<% if (routing) { %>
       imports: [

--- a/packages/schematics/angular/class/files/__name@dasherize____type__.spec.ts.template
+++ b/packages/schematics/angular/class/files/__name@dasherize____type__.spec.ts.template
@@ -1,6 +1,6 @@
 import { <%= classify(name) %> } from './<%= dasherize(name) %><%= type %>';
 
-describe('<%= classify(name) %>', () => {
+describe(<%= classify(name) %>.name, () => {
   it('should create an instance', () => {
     expect(new <%= classify(name) %>()).toBeTruthy();
   });

--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { <%= classify(name) %><%= classify(type) %> } from './<%= dasherize(name) %><%= type ? '.' + dasherize(type): '' %>';
 
-describe('<%= classify(name) %><%= classify(type) %>', () => {
+describe(<%= classify(name) %><%= classify(type) %>.name, () => {
   let component: <%= classify(name) %><%= classify(type) %>;
   let fixture: ComponentFixture<<%= classify(name) %><%= classify(type) %>>;
 

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -292,7 +292,7 @@ describe('Component Schematic', () => {
     const content = tree.readContent('/projects/bar/src/app/foo/foo.route.ts');
     const testContent = tree.readContent('/projects/bar/src/app/foo/foo.route.spec.ts');
     expect(content).toContain('export class FooRoute implements OnInit');
-    expect(testContent).toContain("describe('FooRoute'");
+    expect(testContent).toContain('describe(FooRoute.name');
     expect(tree.files).toContain('/projects/bar/src/app/foo/foo.route.css');
     expect(tree.files).toContain('/projects/bar/src/app/foo/foo.route.html');
   });
@@ -303,7 +303,7 @@ describe('Component Schematic', () => {
     const content = tree.readContent('/projects/bar/src/app/foo/foo.ts');
     const testContent = tree.readContent('/projects/bar/src/app/foo/foo.spec.ts');
     expect(content).toContain('export class Foo implements OnInit');
-    expect(testContent).toContain("describe('Foo'");
+    expect(testContent).toContain('describe(Foo.name');
     expect(tree.files).toContain('/projects/bar/src/app/foo/foo.css');
     expect(tree.files).toContain('/projects/bar/src/app/foo/foo.html');
   });

--- a/packages/schematics/angular/directive/files/__name@dasherize@if-flat__/__name@dasherize__.directive.spec.ts.template
+++ b/packages/schematics/angular/directive/files/__name@dasherize@if-flat__/__name@dasherize__.directive.spec.ts.template
@@ -1,6 +1,6 @@
 import { <%= classify(name) %>Directive } from './<%= dasherize(name) %>.directive';
 
-describe('<%= classify(name) %>Directive', () => {
+describe(<%= classify(name) %>Directive.name, () => {
   it('should create an instance', () => {
     const directive = new <%= classify(name) %>Directive();
     expect(directive).toBeTruthy();

--- a/packages/schematics/angular/guard/files/__name@dasherize__.guard.spec.ts.template
+++ b/packages/schematics/angular/guard/files/__name@dasherize__.guard.spec.ts.template
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { <%= classify(name) %>Guard } from './<%= dasherize(name) %>.guard';
 
-describe('<%= classify(name) %>Guard', () => {
+describe(<%= classify(name) %>Guard.name, () => {
   let guard: <%= classify(name) %>Guard;
 
   beforeEach(() => {

--- a/packages/schematics/angular/interceptor/files/__name@dasherize@if-flat__/__name@dasherize__.interceptor.spec.ts.template
+++ b/packages/schematics/angular/interceptor/files/__name@dasherize@if-flat__/__name@dasherize__.interceptor.spec.ts.template
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { <%= classify(name) %>Interceptor } from './<%= dasherize(name) %>.interceptor';
 
-describe('<%= classify(name) %>Interceptor', () => {
+describe(<%= classify(name) %>Interceptor.name, () => {
   beforeEach(() => TestBed.configureTestingModule({
     providers: [
       <%= classify(name) %>Interceptor

--- a/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.spec.ts.template
+++ b/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.spec.ts.template
@@ -1,6 +1,6 @@
 import { <%= classify(name) %>Pipe } from './<%= dasherize(name) %>.pipe';
 
-describe('<%= classify(name) %>Pipe', () => {
+describe(<%= classify(name) %>Pipe.name, () => {
   it('create an instance', () => {
     const pipe = new <%= classify(name) %>Pipe();
     expect(pipe).toBeTruthy();

--- a/packages/schematics/angular/service/files/__name@dasherize@if-flat__/__name@dasherize__.service.spec.ts.template
+++ b/packages/schematics/angular/service/files/__name@dasherize@if-flat__/__name@dasherize__.service.spec.ts.template
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { <%= classify(name) %>Service } from './<%= dasherize(name) %>.service';
 
-describe('<%= classify(name) %>Service', () => {
+describe(<%= classify(name) %>Service.name, () => {
   let service: <%= classify(name) %>Service;
 
   beforeEach(() => {


### PR DESCRIPTION
Whenever class names change, test descriptions often are overlooked, as IDE's won't change them automatically. By using `Function#name`, we can render the exact same strings without having to worry about changes elsewhere.